### PR TITLE
Also allow poison 2.0 to be compatible with Phoenix 1.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule ExJenkins.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [{:httpoison, "~> 0.10.0"},
-     {:poison, "~> 3.1"}
+     {:poison, "~> 3.1 or ~> 2.0"}
     ]
   end
 end


### PR DESCRIPTION
Phoenix 1.2 only works with Poison 2.0 so this change allows the library to be used with Phoenix 1.2 also.

This should be resolved in Phoenix 1.3, but it's still not released.