### PR TITLE
Fix bug in Jobs.build_with_paramters

### DIFF
--- a/lib/ex_jenkins/endpoints/jobs.ex
+++ b/lib/ex_jenkins/endpoints/jobs.ex
@@ -31,10 +31,7 @@ defmodule ExJenkins.Jobs do
         {:ok, {:started, location}}
   """
   def start_with_parameters(job, params, token \\ ExJenkins.token) do
-    key_values = Enum.map(params, fn({name, value}) -> %{name: name, value: value} end)
-    encoded_params = %{parameter: key_values} |> Poison.encode!()
-
-    post("job/" <> job <> "/buildWithParameters?token=" <> token, {:form, [json: encoded_params]})
+    post("job/" <> job <> "/buildWithParameters?token=" <> token, {:form, params})
     |> handle_start_job_response
   end
 


### PR DESCRIPTION
Unfortunately my previous PR didn't work properly.  Sending the parameters as json when using the '/build' endpoint works, but '/buildWithParameters' just requires a simple form with key/value pairs.

I changed it to '/buildWithParameters' as '/build' does not return the 'Location' header correctly, but I forgot to check if the parameters will still passed correctly to the job.