### PR TITLE
Handle other http status codes

### DIFF
--- a/lib/ex_jenkins/endpoints/folders.ex
+++ b/lib/ex_jenkins/endpoints/folders.ex
@@ -59,6 +59,8 @@ defmodule ExJenkins.Folders do
     case response do
       {:ok, %Response{status_code: 404}} ->
         {:error, :not_found}
+      {:ok, %Response{status_code: status_code}} ->
+        {:error, status_code}
       {:error, %Error{reason: _reason}} ->
         {:error, :generic_error}
     end

--- a/lib/ex_jenkins/endpoints/jenkins.ex
+++ b/lib/ex_jenkins/endpoints/jenkins.ex
@@ -72,6 +72,8 @@ defmodule ExJenkins.Jenkins do
     case response do
       {:ok, %Response{status_code: 404}} ->
         {:error, :not_found}
+      {:ok, %Response{status_code: status_code}} ->
+        {:error, status_code}
       {:error, %Error{reason: _reason}} ->
         {:error, :generic_error}
     end

--- a/lib/ex_jenkins/endpoints/jobs.ex
+++ b/lib/ex_jenkins/endpoints/jobs.ex
@@ -225,6 +225,8 @@ defmodule ExJenkins.Jobs do
     case response do
       {:ok, %Response{status_code: 404}} ->
         {:error, :not_found}
+      {:ok, %Response{status_code: status_code}} ->
+        {:error, status_code}
       {:error, %Error{reason: _reason}} ->
         {:error, :generic_error}
     end

--- a/lib/ex_jenkins/endpoints/queues.ex
+++ b/lib/ex_jenkins/endpoints/queues.ex
@@ -48,6 +48,8 @@ defmodule ExJenkins.Queues do
     case response do
       {:ok, %Response{status_code: 404}} ->
         {:error, :not_found}
+      {:ok, %Response{status_code: status_code}} ->
+        {:error, status_code}
       {:error, %Error{reason: _reason}} ->
         {:error, :generic_error}
     end


### PR DESCRIPTION
If Jenkins returns a HTTP code other than 404, (e.g. 503) the handle_error methods will crash with a match error.  This allows the response to be handled by the caller.