### PR TITLE
Allow tests to run without failing

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,8 @@ defmodule ExJenkins.Mixfile do
      description: @description,
      package: package(),
      deps: deps(),
-     source_url: "https://github.com/pdincau/ex_jenkins"]
+     source_url: "https://github.com/pdincau/ex_jenkins",
+     aliases: [test: "test --no-start"]]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
This allows running `mix test` without having errors.

However, of course, we should add some proper tests.