### PR TITLE
Make header lookup case-insensitive

### DIFF
--- a/lib/ex_jenkins/helpers/headers.ex
+++ b/lib/ex_jenkins/helpers/headers.ex
@@ -2,7 +2,8 @@ defmodule ExJenkins.Headers do
   alias ExJenkins.CrumbServer
 
   def extract(headers, name) do
-    Enum.find(headers, &(String.downcase(elem(&1, 0)) == String.downcase(name)))
+    downcase_name = String.downcase(name)
+    Enum.find(headers, &(String.downcase(elem(&1, 0)) == downcase_name))
   end
 
   def add_authorization_header(headers) do

--- a/lib/ex_jenkins/helpers/headers.ex
+++ b/lib/ex_jenkins/helpers/headers.ex
@@ -2,7 +2,7 @@ defmodule ExJenkins.Headers do
   alias ExJenkins.CrumbServer
 
   def extract(headers, name) do
-    Enum.find(headers, &(elem(&1, 0) == name))
+    Enum.find(headers, &(String.downcase(elem(&1, 0)) == String.downcase(name)))
   end
 
   def add_authorization_header(headers) do

--- a/test/helpers/headers_test.exs
+++ b/test/helpers/headers_test.exs
@@ -2,10 +2,29 @@ defmodule ExJenkins.HeadersTest do
   use ExUnit.Case
 
   describe "extract/2" do
-    test "extract is not case sensitive" do
+    test "not case sensitive lower to upper" do
       headers = [{"header0", 0}, {"header1", 1}]
       name = "HEADER0"
       assert {"header0",0} == ExJenkins.Headers.extract(headers,name)
     end
+
+    test "not case sensitive upper to lower" do
+      headers = [{"HEADER0", 0}, {"HEADER1", 1}]
+      name = "header0"
+      assert {"HEADER0",0} == ExJenkins.Headers.extract(headers,name)
+    end
+
+    test "header not found" do
+      headers = [{"HEADER0", 0}, {"HEADER1", 1}]
+      name = "header3"
+      assert nil == ExJenkins.Headers.extract(headers,name)
+    end
+
+    test "header found and previous ones ignored" do
+      headers = [{"header0", 0}, {"header1", 1}, {"header2", 2}, {"header3", 3}]
+      name = "header3"
+      assert {"header3", 3} == ExJenkins.Headers.extract(headers,name)
+    end
+
   end
 end

--- a/test/helpers/headers_test.exs
+++ b/test/helpers/headers_test.exs
@@ -1,0 +1,11 @@
+defmodule ExJenkins.HeadersTest do
+  use ExUnit.Case
+
+  describe "extract/2" do
+    test "extract is not case sensitive" do
+      headers = [{"header0", 0}, {"header1", 1}]
+      name = "HEADER0"
+      assert {"header0",0} == ExJenkins.Headers.extract(headers,name)
+    end
+  end
+end


### PR DESCRIPTION
Makes the lookup of headers non-case-sensitive, as the HTTP RFC says.